### PR TITLE
Added support for custom database ports

### DIFF
--- a/middleware/auth/authcontroller.js
+++ b/middleware/auth/authcontroller.js
@@ -5,10 +5,12 @@ var jwt = require('jsonwebtoken');
 module.exports = {
 
   login: function (req, res) {
+    var hostComponents = req.body.mysqlHost.split(':');
     mysql.createConnection({
       user: req.body.mysqlUser,
       password: req.body.mysqlPassword,
-      host: req.body.mysqlHost,
+      host: hostComponents[0] || 'localhost',
+      port: hostComponents[1] || '3306',
       multipleStatements: true
     }).then(function(conn) {
         var token = jwt.sign({msg: 'welcome!'}, req.app.locals.secret);


### PR DESCRIPTION
This allows for connecting to a database on a custom port via the common syntax:  localhost:32768

This falls back to the default port 3306.